### PR TITLE
tweak: use vercel

### DIFF
--- a/.changeset/sixty-spies-clean.md
+++ b/.changeset/sixty-spies-clean.md
@@ -1,0 +1,5 @@
+---
+"hono-og": patch
+---
+
+Migrated back to `@vercel/og`.

--- a/src/bun.ts
+++ b/src/bun.ts
@@ -1,4 +1,4 @@
-import * as Og from "@vercel/og";
+import * as Og from "@wevm/vercel-og";
 import { type HonoElement, toReactNode } from "./utils.js";
 
 export type ImageResponseOptions = ConstructorParameters<

--- a/src/package.json
+++ b/src/package.json
@@ -8,7 +8,7 @@
   "exports": {
     ".": {
       "types": "./lib/index.d.ts",
-      "bun": "./lib/index.js",
+      "bun": "./lib/bun.js",
       "worker": "./lib/worker.js",
       "default": "./lib/index.js"
     }
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@wevm/vercel-og": "~0.6.11",
+    "@vercel/og": "~0.6.2",
     "workers-og": "~0.0.20"
   }
 }


### PR DESCRIPTION
Migrating back to `@vercel/og` since we now use `workers-og` for Cloudflare Workers. Unfortunately, `@vercel/og` still breaks on Bun runtimes (segfaults), so adding an entrypoint for Bun to use the fork.