### PR TITLE
fix: memory leak for resvg-wasm

### DIFF
--- a/src/utils/svgToPng.ts
+++ b/src/utils/svgToPng.ts
@@ -16,5 +16,8 @@ export async function svgToPng(svg: string, options: SvgToPngOptions = {}) {
   const pngData = resvg.render();
   const pngBuffer = pngData.asPng();
 
+  pngData.free();
+  pngBuffer.free();
+
   return pngBuffer;
 }

--- a/src/utils/svgToPng.ts
+++ b/src/utils/svgToPng.ts
@@ -17,7 +17,7 @@ export async function svgToPng(svg: string, options: SvgToPngOptions = {}) {
   const pngBuffer = pngData.asPng();
 
   pngData.free();
-  pngBuffer.free();
+  resvg.free()
 
   return pngBuffer;
 }


### PR DESCRIPTION
# Problem

- node/bun server projects using frog + hono-og eventually runs out of memory after certain uptime
- the images in the frames fail to render

![image](https://github.com/wevm/hono-og/assets/18402191/888f5bab-799b-4714-9e46-54bdf0354357)

# Solution

- free the memories after converting svg to png

related 
https://github.com/orgs/vercel/discussions/6117#discussioncomment-8776252